### PR TITLE
Add color use-cases [do not merge]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,7 @@
 {
   "name": "next-navigation",
   "dependencies": {
-    "o-fonts": "^1.4.2",
-    "o-grid": "^3.0.0",
-    "next-sass-setup": "^5.2.0"
+    "next-sass-setup": "^6.0.0"
   },
   "main": [
     "main.scss"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "next-navigation",
   "dependencies": {
-    "next-sass-setup": "^6.0.0"
+    "next-sass-setup": "^5.6.0"
   },
   "main": [
     "main.scss"

--- a/demos/src/config.json
+++ b/demos/src/config.json
@@ -1,6 +1,7 @@
 {
   "options": {
-    "sass": "demos/src/demo.scss"
+    "sass": "demos/src/demo.scss",
+    "dependencies": ["o-fonts@^1.4.0"]
   },
   "demos": [
     {

--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -1,1 +1,5 @@
 @import "./../../main";
+
+body {
+	font-family: MetricWeb, sans-serif;
+}

--- a/main.scss
+++ b/main.scss
@@ -1,5 +1,5 @@
-@import "o-grid/main";
 @import "next-sass-setup/main";
+@import "src/scss/color-use-cases";
 
 .next-navigation,
 .next-navigation__group__items {
@@ -10,11 +10,13 @@
 
 .next-navigation--all {
 	@include oGridRow();
-	background-color: $next-grey-dark;
+	background-color: oColorsGetColorFor(next-navigation, background);
 }
 
 .next-navigation__group {
 	@include oGridColumn((default: 12, S: 6, M: 4, L:2));
+	margin: 10px 0;
+
 	@include oGridRespondTo(S, $until: M) {
 		&:nth-child(2n+1) {
 			clear: both;
@@ -30,28 +32,29 @@
 			clear: both;
 		}
 	}
-	margin: 10px 0;
 }
 
 .next-navigation a {
+	@include oColorsFor(next-navigation-link);
 	font-family: $fontSans;
-	color: $next-grey-lighter;
 	text-decoration: none;
 	padding: 5px;
 	display: block;
 	font-weight: 300;
-	&:hover {
-		background-color: $next-blue;
-		color: $next-white;
+
+	&:hover,
+	&:focus {
+		@include oColorsFor(next-navigation-link-hover);
 	}
 }
 
 
 .next-navigation__group__header {
 	margin: 0;
-	border-bottom: 1px solid $next-grey-dark3;
+	border-bottom: 1px solid oColorsGetColorFor(next-navigation-group-header, border);
+
 	a {
-		color: $next-white;
+		@include oColorsFor(next-navigation-group-header-link);
 		font-size: 18px;
 		font-weight: 500;
 	}

--- a/main.scss
+++ b/main.scss
@@ -36,7 +36,6 @@
 
 .next-navigation a {
 	@include oColorsFor(next-navigation-link);
-	font-family: $fontSans;
 	text-decoration: none;
 	padding: 5px;
 	display: block;

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,0 +1,8 @@
+@include oColorsSetUseCase(next-navigation, background, 'green');
+
+@include oColorsSetUseCase(next-navigation-link, text, 'next-grey-lighter');
+@include oColorsSetUseCase(next-navigation-link-hover, background, 'white');
+@include oColorsSetUseCase(next-navigation-link-hover, text, 'next-blue');
+
+@include oColorsSetUseCase(next-navigation-group-header, border, 'grey-tint3');
+@include oColorsSetUseCase(next-navigation-group-header-link, text, 'white');

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -1,4 +1,4 @@
-@include oColorsSetUseCase(next-navigation, background, 'green');
+@include oColorsSetUseCase(next-navigation, background, 'grey-tint5');
 
 @include oColorsSetUseCase(next-navigation-link, text, 'next-grey-lighter');
 @include oColorsSetUseCase(next-navigation-link-hover, background, 'white');


### PR DESCRIPTION
This is how we could use o-colors in Next components.

It is very useful in Origami for theming and helps rationalising colors at a component level. It'd be great to experiment this approach on Next and see if there are any pain points using it on an actual product.

**Do not merge** (yet): this is using a beta of next-sass-setup, and `next-grey-lighter` is going to change soon into something we decide with designers.

/cc @keirog @tom-parker

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/financial-times/n-navigation/10)
<!-- Reviewable:end -->
